### PR TITLE
Makefile rules to build as shared & static library

### DIFF
--- a/test.c
+++ b/test.c
@@ -34,7 +34,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <sys/time.h>
-#include "zxcvbn.h"
+#include <zxcvbn.h>
 
 /* For pre-compiled headers under windows */
 #ifdef _WIN32

--- a/zxcvbn.c
+++ b/zxcvbn.c
@@ -30,7 +30,7 @@
  * 
  **********************************************************************************/
 
-#include "zxcvbn.h"
+#include <zxcvbn.h>
 #include <ctype.h>
 #include <string.h>
 #include <stdint.h>


### PR DESCRIPTION
These are the patches I'm using to build and test `libzxcvbn.a` and `libzxcvbn.so.0` for Debian.  It would be great if building these libraries were supported by the upstream Makefile.

This patch set might not be what you want to merge -- this is just one way it could be done (my goal was to edit as few lines of the Makefile as possible).

Thanks for your consideration.