### PR TITLE
memory safety fixes (bugs discovered with address sanitizer)

### DIFF
--- a/dict-generate.cpp
+++ b/dict-generate.cpp
@@ -1046,7 +1046,7 @@ static int OutputBinary(ostream *Out, const string & ChkFile, const string & Cha
     Out->write((char *)WordEnds, NumWordEnd);
     h(WordEnds, NumWordEnd);
     OutputSize += NumWordEnd;
-    delete WordEnds;
+    delete [] WordEnds;
 
     StringIntSet_t::iterator Its;
     string Str;

--- a/zxcvbn.c
+++ b/zxcvbn.c
@@ -493,7 +493,7 @@ typedef struct
     uint8_t LeetCnv[sizeof L33TCnv / LEET_NORM_MAP_SIZE + 1];
  /*   uint8_t LeetChr[3]; */
     uint8_t First;
-    uint8_t PossChars[48];
+    uint8_t PossChars[49];
 } DictWork_t;
 
 /**********************************************************************************


### PR DESCRIPTION
This pull request fixes two bugs that were trivially discovered with address sanitizer (-fsanitize=address compiler flag with gcc or clang):

When memory is allocated with "new type[size];" as an array then the correct way to deallocate is to use "delete []" and not "delete".

The second bug is a buffer overflow, the array PossChars is supposed to contain a string of 48 bytes plus a trailing zero, therefore it must be 49 bytes.