### PR TITLE
add license to project

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,22 @@
+The MIT License
+
+Copyright (c) 2015-2017 tsyrogit https://github.com/tsyrogit
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ version when there are 4 or less parts, but will differ significantly when there
 parts (which is likely to be a rare occurrence).
 
 
-##References
+## References
 
 The original coffee-script version is available at 
  https://github.com/lowe/zxcvbn
@@ -83,4 +83,10 @@ The dictionary words are taken from the original coffee script version.
 Dictionary trie encoding (used for by the word lookup code) based on idea from the Caroline
 Word Graph from
 http://www.pathcom.com/~vadco/cwg.html
+
+## License
+
+MIT License
+
+* http://www.opensource.org/licenses/mit-license.php
 


### PR DESCRIPTION
This adds the MIT copyright license to the project to make it easier
for other people to re-use. The other clones of the original zxcvbn
also seem to be doing the same thing.

This is the only identifying information I have on the author, not sure
if that's enough for you?:

    tsyrogit https://github.com/tsyrogit