### PR TITLE
Fix match for decrementing sequences causing heap corruptions

### DIFF
--- a/zxcvbn.c
+++ b/zxcvbn.c
@@ -1491,8 +1491,9 @@ static void SequenceMatch(ZxcMatch_t **Result, const uint8_t *Passwd, int Start,
             {
                 ++Len;
                 ++Passwd;
+                break;
             }
-            else if ((Next > SetHigh) || (Next < SetLow) || (Passwd[1] != Next))
+            if ((Next > SetHigh) || (Next < SetLow) || (Passwd[1] != Next))
                 break;
             ++Len;
             ++Passwd;


### PR DESCRIPTION
This was causing heap corruptions (write past array boundary) in ZxcvbnMatch for passwords ending with 09 for example