### PR TITLE
Fix for GCC15/c++23

### DIFF
--- a/dict-generate.cpp
+++ b/dict-generate.cpp
@@ -23,6 +23,7 @@
  **********************************************************************************/
 
 #include <algorithm>
+#include <cstdint>
 #include <iostream>
 #include <string>
 #include <fstream>


### PR DESCRIPTION
GCC 15 default standard is C++23. This include is needed to build zxcvbn with that language level.