### PR TITLE
use const for these arrays

### DIFF
--- a/dict-generate.cpp
+++ b/dict-generate.cpp
@@ -1246,7 +1246,7 @@ int OutputCode(ostream *Out, bool Cmnts, const string & CharSet, StringIntSet_t 
     unsigned int Len = ((NodeData.size() + 7) / 8);
     OutputSize += Len;
     x = 999;
-    *Out << "static unsigned char WordEndBits[" << Len << "] =\n{";
+    *Out << "static const unsigned char WordEndBits[" << Len << "] =\n{";
     Index = 0;
     unsigned int v = 0;
     unsigned int y = 0;

--- a/zxcvbn.c
+++ b/zxcvbn.c
@@ -1228,7 +1228,7 @@ static void SpatialMatch(ZxcMatch_t **Result, const uint8_t *Passwd, int Start, 
 
 /* The possible date formats ordered by length (d for day, m for month, */
 /*  y for year, ? for separator) */
-static const char *Formats[] =
+static const char * const Formats[] =
 {
     "yyyy",
     "d?m?yy",


### PR DESCRIPTION
so they don't appear in the .data section. With const WordEndBits ends up in the .rodata section and Formats in the .data.rel.ro section.