### PR TITLE
Fix static library retaining stale object code

### DIFF
--- a/makefile
+++ b/makefile
@@ -36,7 +36,7 @@ test-statlib: test.c libzxcvbn.a
 	$(CC) $(CPPFLAGS) $(CFLAGS) -o $@ $^ $(LDFLAGS) -lm
 
 libzxcvbn.a: zxcvbn-inline.o
-	$(AR) cvq $@ $^
+	$(AR) cvr $@ $^
 
 test-file: test.c zxcvbn-file.o
 	$(CC) $(CPPFLAGS) $(CFLAGS) \


### PR DESCRIPTION
The "q" flag makes ar append to end of the archive, which means libzxcvbn.a would contain multiple copies of zxcvbn-inline.o, and later the linker would take the first copy, which contains stale code. Thus, if you change e.g. zxcvbn.c and rebuild, and then link libzxcvbn.a into some application, that application will not get the changes you just made.

Instead use the "r" flag, which replaces the object code inside the archive.